### PR TITLE
undefined values for isKeyframe fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,6 @@
     "@babel/preset-env": "^7.0.0-beta.42",
     "circular-json": "^0.5.1",
     "eslint-utils": "2.1.0",
-    "lodash": "4.17.19"
+    "lodash": "^4.17.21"
   }
 }

--- a/src/SimpleBlock.js
+++ b/src/SimpleBlock.js
@@ -16,7 +16,7 @@ class SimpleBlock {
     this.trackNumber = null;
     this.timeCode = -1;
     this.flags = null;
-    this.keyframe = false;
+    this.keyFrame = false;
     this.invisible = false;
     this.lacing = NO_LACING;
     this.discardable = false;
@@ -46,7 +46,7 @@ class SimpleBlock {
     this.trackNumber = null;
     this.timeCode = null;
     this.flags = null;
-    this.keyframe = false;
+    this.keyFrame = false;
     this.invisible = false;
     this.lacing = NO_LACING;
     this.discardable = false;
@@ -105,7 +105,7 @@ class SimpleBlock {
       if (this.flags === null)
         return null;
 
-      this.keyframe = (((this.flags >> 7) & 0x01) === 0) ? false : true;
+      this.keyFrame = (((this.flags >> 7) & 0x01) === 0) ? false : true;
       this.invisible = (((this.flags >> 2) & 0x01) === 0) ? true : false;
       this.lacing = ((this.flags & 0x06) >> 1);
       if (this.lacing > 3 || this.lacing < 0)


### PR DESCRIPTION
Right now, the `isKeyframe` key for the video packets is being populated as undefined. The root cause is a minor typo, which I have fixed in this PR. Also, a package (underscore) vulnerability has been fixed.

**This is a screenshot taken from the current jswebm [demo](https://jscodec.github.io/jswebm-demo/):**
<img width="1440" alt="Screenshot 2021-11-27 at 2 00 26 PM" src="https://user-images.githubusercontent.com/26036974/143674249-9c364f72-46cb-4538-a9bd-4354999e78ee.png">


**This is a screenshot from a [demo](https://js-g1zoe2.stackblitz.io/) built using the updated jswebm :**
<img width="1440" alt="Screenshot 2021-11-27 at 2 13 41 PM" src="https://user-images.githubusercontent.com/26036974/143674674-c2647f66-0b1f-4b77-863f-d1a1dab132ea.png">
